### PR TITLE
Add support for retry upload to zooniverse after upload failure

### DIFF
--- a/gravityspy_ligo/subject/subject.py
+++ b/gravityspy_ligo/subject/subject.py
@@ -243,6 +243,7 @@ class GravitySpySubject:
                     save_success = True
                 except:
                     print(f"Upload failed, retry number {retry}")
+                    retry += 1
                     continue
             self.zooniverse_id = int(subject.id)
             for idx, image in enumerate(images_for_subject_part):

--- a/gravityspy_ligo/subject/subject.py
+++ b/gravityspy_ligo/subject/subject.py
@@ -27,6 +27,7 @@ import os
 import datetime
 import panoptes_client
 import glob
+import time
 
 RETRY_DEFAULT = 3
 
@@ -244,6 +245,7 @@ class GravitySpySubject:
                 except:
                     print(f"Upload failed, retry number {retry}")
                     retry += 1
+                    time.sleep(1)
                     continue
             self.zooniverse_id = int(subject.id)
             for idx, image in enumerate(images_for_subject_part):


### PR DESCRIPTION
This MR attempts to address an ongoing issue where a small number of uploads to zooniverse fail, bringing down the entire pipeline.